### PR TITLE
Potentielle erreur mémoire, détecté en simulation

### DIFF
--- a/software/raspberry/superviseur-robot/tasks.cpp
+++ b/software/raspberry/superviseur-robot/tasks.cpp
@@ -336,13 +336,14 @@ void Tasks::StartRobotTask(void *arg) {
         cout << ")" << endl;
 
         cout << "Movement answer: " << msgSend->ToString() << endl << flush;
-        WriteInQueue(&q_messageToMon, msgSend);  // msgSend will be deleted by sendToMon
-
+        
         if (msgSend->GetID() == MESSAGE_ANSWER_ACK) {
             rt_mutex_acquire(&mutex_robotStarted, TM_INFINITE);
             robotStarted = 1;
             rt_mutex_release(&mutex_robotStarted);
         }
+        
+        WriteInQueue(&q_messageToMon, msgSend);  // msgSend will be deleted by sendToMon
     }
 }
 


### PR DESCRIPTION
Bonjour,

En aidant un groupe à faire fonctionner leur simulation, j'ai découvert une erreur dans l'utilisation de la mémoire:
`WriteInQueue(&q_messageToMon, msgSend);` supprimant `msgSend` dès qu'il est envoyé, on ne peut se permettre de tester `msgSend` après l'avoir mis dans la queue.

Cette erreur est détectée en simulation dès lors que la machine utilisée offre certaines capacités (je ne suis pas allé jusqu'à voir quelles capacités minimales était nécessaires pour déclencher l'erreur).